### PR TITLE
Set VHP and POB in name service for PoB test

### DIFF
--- a/tests/pob/pob_test.go
+++ b/tests/pob/pob_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"koinos-integration-tests/integration"
+	"koinos-integration-tests/integration/name_service"
 	"koinos-integration-tests/integration/token"
 	"testing"
 	"time"
@@ -58,6 +59,14 @@ func TestPob(t *testing.T) {
 
 	t.Logf("Uploading PoB contract")
 	_, err = integration.UploadSystemContract(client, "../../contracts/pob.wasm", pobKey, "pob")
+	integration.NoError(t, err)
+
+	nameService := name_service.GetNameService(client)
+
+	_, err = nameService.SetRecord(t, genesisKey, "vhp", vhpKey.AddressBytes())
+	integration.NoError(t, err)
+
+	_, err = nameService.SetRecord(t, genesisKey, "pob", pobKey.AddressBytes())
 	integration.NoError(t, err)
 
 	t.Logf("Minting KOIN")


### PR DESCRIPTION
## Brief description
Set the VHP and POB in name service for the POB test.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
=== RUN   TestPob
    integration.go:638: Waiting 1s for chain to be ready...
    integration.go:638: Waiting 2s for chain to be ready...
    integration.go:638: Waiting 4s for chain to be ready...
    integration.go:638: Waiting 5s for chain to be ready...
    integration.go:638: Waiting 5s for chain to be ready...
    integration.go:90: Uploading Name Service contract
    integration.go:94: Overriding get_contract_name
    integration.go:98: Overriding get_contract_address
    pob_test.go:52: Uploading KOIN contract
    pob_test.go:56: Uploading VHP contract
    pob_test.go:60: Uploading PoB contract
    pob_test.go:72: Minting KOIN
    pob_test.go:79: Burning KOIN
    pob_test.go:118: Register Public Key
    pob_test.go:156: Enabling PoB
    pob_test.go:200: Block Height 32
    pob_test.go:200: Block Height 32
    pob_test.go:200: Block Height 45
    pob_test.go:245: Transaction included in block 47
--- PASS: TestPob (27.53s)
PASS
ok  	[secure]-integration-tests/tests/pob	27.558s
```
