### PR TITLE
Shift ports

### DIFF
--- a/tests/add_thunk/add_thunk_test.go
+++ b/tests/add_thunk/add_thunk_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAddThunk(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	genesisKey, err := integration.GetKey(integration.Genesis)
 	integration.NoError(t, err)

--- a/tests/add_thunk/docker-compose.yml
+++ b/tests/add_thunk/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/bucket_brigade/bucket_brigade_test.go
+++ b/tests/bucket_brigade/bucket_brigade_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestBucketBrigade(t *testing.T) {
-	producerClient := jsonrpc.NewClient("http://localhost:8080/")
-	endClient := jsonrpc.NewClient("http://localhost:8082/")
+	producerClient := jsonrpc.NewClient("http://localhost:28080/")
+	endClient := jsonrpc.NewClient("http://localhost:28082/")
 
 	headInfoResponse := chain.GetHeadInfoResponse{}
 

--- a/tests/bucket_brigade/docker-compose.yml
+++ b/tests/bucket_brigade/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     networks:
       - producer
     ports:
-      - "8080:8080"
+      - "28080:8080"
     configs:
       - source: koinos-descriptors
         target: /root/.koinos/jsonrpc/descriptors/koinos_descriptors.pb
@@ -178,7 +178,7 @@ services:
     networks:
       - bucket2
     ports:
-      - "8082:8080"
+      - "28082:8080"
     configs:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb

--- a/tests/claim/claim_test.go
+++ b/tests/claim/claim_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 func TestClaim(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	claimKey, err := integration.GetKey(integration.Claim)
 	integration.NoError(t, err)

--- a/tests/claim/docker-compose.yml
+++ b/tests/claim/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/claim_delegation/claim_delegation_test.go
+++ b/tests/claim_delegation/claim_delegation_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 func TestClaimDelegation(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	claimKey, err := integration.GetKey(integration.Claim)
 	integration.NoError(t, err)

--- a/tests/claim_delegation/docker-compose.yml
+++ b/tests/claim_delegation/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/error/docker-compose.yml
+++ b/tests/error/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/error/error_test.go
+++ b/tests/error/error_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestError(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	genesisKey, err := integration.GetKey(integration.Genesis)
 	integration.NoError(t, err)

--- a/tests/failures/docker-compose.yml
+++ b/tests/failures/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/failures/failures_test.go
+++ b/tests/failures/failures_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFailures(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	t.Logf("Generating key for failures")
 	failuresKey, err := util.GenerateKoinosKey()

--- a/tests/governance/docker-compose.yml
+++ b/tests/governance/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/governance/governance_test.go
+++ b/tests/governance/governance_test.go
@@ -33,7 +33,7 @@ const (
 )
 
 func TestGovernance(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	genesisKey, err := integration.GetKey(integration.Genesis)
 	integration.NoError(t, err)

--- a/tests/koin/docker-compose.yml
+++ b/tests/koin/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/koin/koin_test.go
+++ b/tests/koin/koin_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestKoin(t *testing.T) {
-	client := integration.NewKoinosMQClient("amqp://guest:guest@localhost:5672/")
+	client := integration.NewKoinosMQClient("amqp://guest:guest@localhost:25672/")
 
 	t.Logf("Generating key for alice")
 	aliceKey, err := util.GenerateKoinosKey()
@@ -49,9 +49,11 @@ func TestKoin(t *testing.T) {
 	integration.NoError(t, err)
 
 	balance, err := koin.Balance(aliceKey.AddressBytes())
+	integration.NoError(t, err)
 	require.EqualValues(t, uint64(1000), balance)
 
 	balance, err = koin.Balance(bobKey.AddressBytes())
+	integration.NoError(t, err)
 	require.EqualValues(t, uint64(0), balance)
 
 	supply, err = koin.TotalSupply()
@@ -64,9 +66,11 @@ func TestKoin(t *testing.T) {
 	integration.NoError(t, err)
 
 	balance, err = koin.Balance(aliceKey.AddressBytes())
+	integration.NoError(t, err)
 	require.EqualValues(t, uint64(1000), balance)
 
 	balance, err = koin.Balance(bobKey.AddressBytes())
+	integration.NoError(t, err)
 	require.EqualValues(t, uint64(0), balance)
 
 	supply, err = koin.TotalSupply()
@@ -76,15 +80,18 @@ func TestKoin(t *testing.T) {
 
 	t.Logf("Fail to burn more than balance")
 	balance, err = koin.Balance(aliceKey.AddressBytes())
+	integration.NoError(t, err)
 	require.EqualValues(t, uint64(1000), balance)
 
 	err = koin.Burn(aliceKey, balance+1)
 	integration.NoError(t, err)
 
 	balance, err = koin.Balance(aliceKey.AddressBytes())
+	integration.NoError(t, err)
 	require.EqualValues(t, uint64(1000), balance)
 
 	balance, err = koin.Balance(bobKey.AddressBytes())
+	integration.NoError(t, err)
 	require.EqualValues(t, uint64(0), balance)
 
 	supply, err = koin.TotalSupply()

--- a/tests/name_service/docker-compose.yml
+++ b/tests/name_service/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/name_service/name_service_test.go
+++ b/tests/name_service/name_service_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNameService(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	genesisKey, err := integration.GetKey(integration.Genesis)
 	integration.NoError(t, err)

--- a/tests/pob/docker-compose.yml
+++ b/tests/pob/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,7 +36,7 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080
 
   block_producer:

--- a/tests/pob/pob_test.go
+++ b/tests/pob/pob_test.go
@@ -25,7 +25,7 @@ const (
 )
 
 func TestPob(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	koinKey, err := integration.GetKey(integration.Koin)
 	integration.NoError(t, err)

--- a/tests/propose_block/docker-compose.yml
+++ b/tests/propose_block/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   p2p:
     image: koinos/koinos-p2p:${P2P_TAG:-latest}
@@ -43,7 +43,7 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080
 
   block_producer:

--- a/tests/propose_block/propose_block_test.go
+++ b/tests/propose_block/propose_block_test.go
@@ -74,8 +74,8 @@ func TestProposeBlock(t *testing.T) {
 		panic("Timer expired")
 	}()
 
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
-	mqClient := mq.NewClient("amqp://guest:guest@localhost:5672/", mq.NoRetry)
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
+	mqClient := mq.NewClient("amqp://guest:guest@localhost:25672/", mq.NoRetry)
 	mqClient.Start(context.Background())
 
 	koinKey, err := integration.GetKey(integration.Koin)

--- a/tests/publish_transaction/docker-compose.yml
+++ b/tests/publish_transaction/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,7 +36,7 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080
 
   block_producer:

--- a/tests/publish_transaction/publish_transaction_test.go
+++ b/tests/publish_transaction/publish_transaction_test.go
@@ -76,7 +76,7 @@ func TestPublishTransaction(t *testing.T) {
 		t.Error(err)
 	}
 
-	krpc := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	krpc := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	ops := make([]*protocol.Operation, 1)
 	ops[0] = &protocol.Operation{

--- a/tests/publish_transaction/publish_transaction_test.go
+++ b/tests/publish_transaction/publish_transaction_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPublishTransaction(t *testing.T) {
-	rpcClient := jsonrpc.NewClient("http://localhost:8080/")
+	rpcClient := jsonrpc.NewClient("http://localhost:28080/")
 
 	headInfoResponse := chain.GetHeadInfoResponse{}
 

--- a/tests/resource/docker-compose.yml
+++ b/tests/resource/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/resource/resource_test.go
+++ b/tests/resource/resource_test.go
@@ -48,7 +48,7 @@ func getMarkets(client integration.Client, resourceAddress []byte) (*resources.R
 }
 
 func TestResource(t *testing.T) {
-	client := integration.NewKoinosMQClient("amqp://guest:guest@localhost:5672/")
+	client := integration.NewKoinosMQClient("amqp://guest:guest@localhost:25672/")
 
 	genesisKey, err := integration.GetKey(integration.Genesis)
 	integration.NoError(t, err)

--- a/tests/transaction_error/docker-compose.yml
+++ b/tests/transaction_error/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/transaction_error/transaction_error_test.go
+++ b/tests/transaction_error/transaction_error_test.go
@@ -22,8 +22,8 @@ func TestTransactionError(t *testing.T) {
 		panic("Timer expired")
 	}()
 
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
-	mqClient := mq.NewClient("amqp://guest:guest@localhost:5672/", mq.NoRetry)
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
+	mqClient := mq.NewClient("amqp://guest:guest@localhost:25672/", mq.NoRetry)
 	mqClient.Start(context.Background())
 
 	t.Logf("Generating key for alice")

--- a/tests/vhp/docker-compose.yml
+++ b/tests/vhp/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   amqp:
     image: rabbitmq:alpine
     ports:
-      - "5672:5672"
+      - "25672:5672"
 
   chain:
     image: koinos/koinos-chain:${CHAIN_TAG:-latest}
@@ -36,5 +36,5 @@ services:
       - source: koinos-descriptors
         target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
     ports:
-      - "8080:8080"
+      - "28080:8080"
     command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080

--- a/tests/vhp/vhp_test.go
+++ b/tests/vhp/vhp_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestVhp(t *testing.T) {
-	client := kjsonrpc.NewKoinosRPCClient("http://localhost:8080/")
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
 
 	t.Logf("Generating key for alice")
 	aliceKey, err := util.GenerateKoinosKey()


### PR DESCRIPTION
## Brief description

Uses different ports for integration tests (shifted +20000) to avoid conflicts with published koinos mainnet and harbinger ports to allow running integration tests locally while running nodes on the same machine.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
