### PR TITLE
Add test for mempool pending nonce

### DIFF
--- a/tests/pending_nonce/docker-compose.yml
+++ b/tests/pending_nonce/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  amqp:
+    image: rabbitmq:alpine
+    ports:
+      - "25673:5672"
+
+  chain:
+    image: koinos/koinos-chain:${CHAIN_TAG:-latest}
+    depends_on:
+      - amqp
+    configs:
+      - source: genesis-data
+        target: /koinos/chain/genesis_data.json
+    command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/
+
+  mempool:
+    image: koinos/koinos-mempool:${MEMPOOL_TAG:-latest}
+    depends_on:
+      - amqp
+      - chain
+    command: -a amqp://guest:guest@amqp:5672/
+
+  block_store:
+    image: koinos/koinos-block-store:${BLOCK_STORE_TAG:-latest}
+    depends_on:
+      - amqp
+      - chain
+    command: -a amqp://guest:guest@amqp:5672/
+
+  jsonrpc:
+    image: koinos/koinos-jsonrpc:${JSONRPC_TAG:-latest}
+    depends_on:
+      - amqp
+      - chain
+    configs:
+      - source: koinos-descriptors
+        target: /koinos/jsonrpc/descriptors/koinos_descriptors.pb
+    ports:
+      - "28080:8080"
+    command: --basedir=/koinos -a amqp://guest:guest@amqp:5672/ -L /tcp/8080 -l debug

--- a/tests/pending_nonce/main.go
+++ b/tests/pending_nonce/main.go
@@ -1,0 +1,1 @@
+package pendingNonce

--- a/tests/pending_nonce/pending_nonce_test.go
+++ b/tests/pending_nonce/pending_nonce_test.go
@@ -1,0 +1,120 @@
+package pendingNonce
+
+import (
+	"context"
+	"koinos-integration-tests/integration"
+	"testing"
+
+	"github.com/koinos/koinos-proto-golang/v2/koinos/chain"
+	"github.com/koinos/koinos-proto-golang/v2/koinos/protocol"
+	util "github.com/koinos/koinos-util-golang/v2"
+	kjsonrpc "github.com/koinos/koinos-util-golang/v2/rpc"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func createTransactionWithNonce(client integration.Client, key *util.KoinosKey, nonce uint64) (*protocol.Transaction, error) {
+	var nonceValue chain.ValueType
+	nonceValue.Kind = &chain.ValueType_Uint64Value{Uint64Value: nonce}
+	nonceBytes, err := proto.Marshal(&nonceValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return integration.CreateTransaction(
+		client,
+		[]*protocol.Operation{},
+		key,
+		func(t *protocol.Transaction) error {
+			t.Header.Nonce = nonceBytes
+			t.Header.RcLimit = 100000
+
+			return nil
+		})
+}
+
+func TestPublishTransaction(t *testing.T) {
+	client := kjsonrpc.NewKoinosRPCClient("http://localhost:28080/")
+
+	integration.AwaitChain(t, client)
+
+	genesisKey, err := integration.GetKey(integration.Genesis)
+	integration.NoError(t, err)
+
+	_, err = client.GetAccountNonce(context.Background(), genesisKey.AddressBytes())
+	integration.NoError(t, err)
+
+	//rcLimit, err := client.GetAccountRc(context.Background(), genesisKey.AddressBytes())
+	//integration.NoError(t, err)
+
+	//rcLimit /= 20
+
+	//ops := make([]*protocol.Operation, 0)
+
+	// Nonce 1 and 2 should fail
+	/*
+		_, err = client.SubmitTransaction(context.Background(), ops, genesisKey, &kjsonrpc.SubmissionParams{Nonce: 1, RCLimit: rcLimit}, true)
+		if err == nil {
+			t.Error("nonce error expected")
+		}
+
+		nonce, _ := client.GetAccountNonce(context.Background(), genesisKey.AddressBytes())
+		fmt.Printf("%v", nonce)
+
+		_, err = client.SubmitTransaction(context.Background(), ops, genesisKey, &kjsonrpc.SubmissionParams{Nonce: 2, RCLimit: rcLimit}, true)
+		if err == nil {
+			t.Error("nonce error expected")
+		}
+
+		nonce, _ = client.GetAccountNonce(context.Background(), genesisKey.AddressBytes())
+		fmt.Printf("%v", nonce)
+	*/
+
+	// Nonce 0 and 2 should fail
+	trx, err := createTransactionWithNonce(client, genesisKey, 0)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	require.Error(t, err, "nonce error expected")
+
+	trx, err = createTransactionWithNonce(client, genesisKey, 2)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	require.Error(t, err, "nonce error expected")
+
+	// Submitting nonce 1 should work and then 0 and 1 should then fail
+	trx, err = createTransactionWithNonce(client, genesisKey, 1)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	integration.NoError(t, err)
+
+	trx, err = createTransactionWithNonce(client, genesisKey, 0)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	require.Error(t, err, "nonce error expected")
+
+	trx, err = createTransactionWithNonce(client, genesisKey, 1)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	require.Error(t, err, "nonce error expected")
+
+	// Nonce 2 should now work and 0, 1, and 2 should then fail
+	trx, err = createTransactionWithNonce(client, genesisKey, 2)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	integration.NoError(t, err)
+
+	trx, err = createTransactionWithNonce(client, genesisKey, 0)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	require.Error(t, err, "nonce error expected")
+
+	trx, err = createTransactionWithNonce(client, genesisKey, 1)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	require.Error(t, err, "nonce error expected")
+
+	trx, err = createTransactionWithNonce(client, genesisKey, 2)
+	integration.NoError(t, err)
+	_, err = integration.SubmitTransaction(client, trx)
+	require.Error(t, err, "nonce error expected")
+}

--- a/tests/pending_nonce/pending_nonce_test.go
+++ b/tests/pending_nonce/pending_nonce_test.go
@@ -44,32 +44,6 @@ func TestPublishTransaction(t *testing.T) {
 	_, err = client.GetAccountNonce(context.Background(), genesisKey.AddressBytes())
 	integration.NoError(t, err)
 
-	//rcLimit, err := client.GetAccountRc(context.Background(), genesisKey.AddressBytes())
-	//integration.NoError(t, err)
-
-	//rcLimit /= 20
-
-	//ops := make([]*protocol.Operation, 0)
-
-	// Nonce 1 and 2 should fail
-	/*
-		_, err = client.SubmitTransaction(context.Background(), ops, genesisKey, &kjsonrpc.SubmissionParams{Nonce: 1, RCLimit: rcLimit}, true)
-		if err == nil {
-			t.Error("nonce error expected")
-		}
-
-		nonce, _ := client.GetAccountNonce(context.Background(), genesisKey.AddressBytes())
-		fmt.Printf("%v", nonce)
-
-		_, err = client.SubmitTransaction(context.Background(), ops, genesisKey, &kjsonrpc.SubmissionParams{Nonce: 2, RCLimit: rcLimit}, true)
-		if err == nil {
-			t.Error("nonce error expected")
-		}
-
-		nonce, _ = client.GetAccountNonce(context.Background(), genesisKey.AddressBytes())
-		fmt.Printf("%v", nonce)
-	*/
-
 	// Nonce 0 and 2 should fail
 	trx, err := createTransactionWithNonce(client, genesisKey, 0)
 	integration.NoError(t, err)


### PR DESCRIPTION
## Brief description

Tests the correct interaction between chain and mempool when submitting transactions with sequentially increasing nonces prior to the transactions being included in a block.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
```
❯ ./run.sh pending_nonce                               
~/dev/koinos-integration-tests/tests/pending_nonce ~/dev/koinos-integration-tests
[+] Running 6/6
 ✔ Network pending_nonce_default          Created                                                                                                                                                                                                     0.1s 
 ✔ Container pending_nonce-amqp-1         Started                                                                                                                                                                                                     0.2s 
 ✔ Container pending_nonce-chain-1        Started                                                                                                                                                                                                     0.3s 
 ✔ Container pending_nonce-block_store-1  Started                                                                                                                                                                                                     0.5s 
 ✔ Container pending_nonce-jsonrpc-1      Started                                                                                                                                                                                                     0.5s 
 ✔ Container pending_nonce-mempool-1      Started                                                                                                                                                                                                     0.5s 
=== RUN   TestPublishTransaction
    integration.go:699: Waiting 1s for chain to be ready...
    integration.go:699: Waiting 2s for chain to be ready...
    integration.go:699: Waiting 4s for chain to be ready...
--- PASS: TestPublishTransaction (7.04s)
PASS
ok      koinos-integration-tests/tests/pending_nonce    7.056s
[+] Running 6/6
 ✔ Container pending_nonce-jsonrpc-1      Removed                                                                                                                                                                                                     0.2s 
 ✔ Container pending_nonce-mempool-1      Removed                                                                                                                                                                                                     0.3s 
 ✔ Container pending_nonce-block_store-1  Removed                                                                                                                                                                                                     0.1s 
 ✔ Container pending_nonce-chain-1        Removed                                                                                                                                                                                                     0.3s 
 ✔ Container pending_nonce-amqp-1         Removed                                                                                                                                                                                                     1.2s 
 ✔ Network pending_nonce_default          Removed                                                                                                                                                                                                     0.2s 
~/dev/koinos-integration-tests
```