### PR TITLE
Remove sequential_nonce block producer resource restrictions

### DIFF
--- a/tests/sequential_nonce/docker-compose.yml
+++ b/tests/sequential_nonce/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     configs:
       - source: pob-private-key
         target: /root/.koinos/block_producer/private.key
-    command: -a amqp://guest:guest@amqp_producer:5672/ --algorithm=federated --gossip-production=false --resources-lower-bound=40 --resources-upper-bound=50
+    command: -a amqp://guest:guest@amqp_producer:5672/ --algorithm=federated --gossip-production=false
 
   #api
   amqp_api:


### PR DESCRIPTION
## Brief description

Removes resource limits on sequential nonce test. Previously, the resource limit needed to be decreased to not overflow blocks. With these changes, the limits are no longer needed as the block producer properly estimates the block's total resource usage. 

This PR requires koinos/koinos-chain#852, koinos/koinos-mempool#114, and koinos/koinos-block-producer#152.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
